### PR TITLE
.BEAT time correction and additional player /commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,3 +5,7 @@ A fork of [theodis's linux port](https://gitlab.com/theodis3/tethealla).
 ## Features
 ### Chat commands:
 * `/reloadq`: Reloads all quests. Requires GM privileges.
+* `/showmats`: Shows used ATP, MST, EVP, DFP, LUK materials.
+* `/resetmymaterials`: Resets ATP, MST, EVP, DFP, LUK materials to 0 and adjusts stats.
+* `/modsectionid`: Changes character section id.
+* `/modcharname`: Change character name without altering section id.

--- a/src/login_server/login_server.c
+++ b/src/login_server/login_server.c
@@ -1385,11 +1385,13 @@ void start_encryption(BANANA* connect)
   connect->connected = (unsigned) servertime;
 }
 
-//FIXME: Dummied out time stuff
+//FIXME: Converted from Windows SYSTEMTIME to linux time_t
 void SendB1 (BANANA* client)
 {
 //  SYSTEMTIME rawtime;
-
+	time_t rawtime = time(NULL);
+	struct tm tm = *localtime(&rawtime);
+	
   if ((client->guildcard) && (client->slotnum != -1))
   {
 //    GetSystemTime (&rawtime);
@@ -1397,12 +1399,14 @@ void SendB1 (BANANA* client)
     memset (&client->encryptbuf[0x08], 0, 28);
 //    sprintf (&client->encryptbuf[8], "%u:%02u:%02u: %02u:%02u:%02u.%03u", rawtime.wYear, rawtime.wMonth, rawtime.wDay,
 //      rawtime.wHour, rawtime.wMinute, rawtime.wSecond, rawtime.wMilliseconds );
+    sprintf (&client->encryptbuf[8], "%u:%02u:%02u: %02u:%02u:%02u.%03u", tm.tm_year + 1900, tm.tm_mon + 1, tm.tm_mday, tm.tm_hour, tm.tm_min, tm.tm_sec, 0 );
     cipher_ptr = &client->server_cipher;
     encryptcopy (client, &client->encryptbuf[0], 0x24 );
   }
   else
     client->todc = 1;
 }
+
 
 void Send1A (const char *mes, BANANA* client)
 {

--- a/src/login_server/login_server.c
+++ b/src/login_server/login_server.c
@@ -1390,7 +1390,7 @@ void SendB1 (BANANA* client)
 {
 //  SYSTEMTIME rawtime;
 	time_t rawtime = time(NULL);
-	struct tm tm = *localtime(&rawtime);
+	struct tm tm = *gmtime(&rawtime);
 	
   if ((client->guildcard) && (client->slotnum != -1))
   {

--- a/src/ship_server/ship_server.c
+++ b/src/ship_server/ship_server.c
@@ -12137,6 +12137,24 @@ void Send06 (BANANA* client)
           SendB0 ("Please LOGOFF and reconnect!", client);
         }
       }
+      
+      //Credit: TOFUMAN, who posted this on the Ephiniea forums
+      if (!strcmp(myCommand, "modsectionid"))
+      {
+        if ( myCmdArgs == 0 )
+          SendB0 ("Need to specify Section ID, 0-8", client);
+        else
+        {
+          unsigned int sectionID = atoi(myArgs[0]);
+          if ((sectionID >= ID_Viridia) && (sectionID <= ID_Whitill))
+          {
+            client->character.sectionID = sectionID;
+            SendB0 ("Please change blocks to reflect changes...", client);
+          }
+          else
+            SendB0 ("Invalid Section ID specified...", client);
+        }
+      }
     }
   }
   else

--- a/src/ship_server/ship_server.c
+++ b/src/ship_server/ship_server.c
@@ -12114,6 +12114,29 @@ void Send06 (BANANA* client)
           SendB0 (usedmats, client);
         }
       }
+
+      if ( !strcmp ( myCommand, "resetmymaterials" ) )
+      {
+        if ( client->lobbyNum < 0x10 )
+          SendB0 ("Can't reset mats in the lobby!!!", client);
+        else
+        {
+          client->character.ATP -= ( client->matuse[0] * 2 );
+          client->matuse[0] = 0;
+          client->character.MST -= ( client->matuse[1] * 2 );
+          client->matuse[1] = 0;
+          client->character.EVP -= ( client->matuse[2] * 2 );
+          client->matuse[2] = 0;
+          client->character.DFP -= ( client->matuse[3] * 2 );
+          client->matuse[3] = 0;
+          client->character.LCK = 10;
+          client->matuse[4] = 0;
+          char resetmats[60];
+          sprintf(resetmats, "Reset Complete: ATP:%d MST:%d EVP:%d DFP:%d LCK:%d\n", client->matuse[0], client->matuse[1], client->matuse[2], client->matuse[3], client->matuse[4]);
+          SendB0 (resetmats, client);
+          SendB0 ("Please LOGOFF and reconnect!", client);
+        }
+      }
     }
   }
   else

--- a/src/ship_server/ship_server.c
+++ b/src/ship_server/ship_server.c
@@ -12142,13 +12142,48 @@ void Send06 (BANANA* client)
       if (!strcmp(myCommand, "modsectionid"))
       {
         if ( myCmdArgs == 0 )
-          SendB0 ("Need to specify Section ID, 0-8", client);
+          SendB0 ("Need to specify Section ID 0-9...", client);
         else
         {
           unsigned int sectionID = atoi(myArgs[0]);
           if ((sectionID >= ID_Viridia) && (sectionID <= ID_Whitill))
           {
             client->character.sectionID = sectionID;
+            switch (sectionID)
+            {
+              case 0:
+                SendB0 ("Section ID changed to Viridia.", client);
+                break;
+              case 1:
+                SendB0 ("Section ID changed to Greennill.", client);
+                break;
+              case 2:
+                SendB0 ("Section ID changed to Skyly.", client);
+                break;
+              case 3:
+                SendB0 ("Section ID changed to Bluefull.", client);
+                break;
+              case 4:
+                SendB0 ("Section ID changed to Purplenum.", client);
+                break;
+              case 5:
+                SendB0 ("Section ID changed to Pinkal.", client);
+                break;
+              case 6:
+                SendB0 ("Section ID changed to Redria.", client);
+                break;
+              case 7:
+                SendB0 ("Section ID changed to Oran.", client);
+                break;
+              case 8:
+                SendB0 ("Section ID changed to Yellowboze.", client);
+                break;
+              case 9:
+                SendB0 ("Section ID changed to Whitill.", client);
+                break;
+              default:
+                break;
+            }
             SendB0 ("Please change blocks to reflect changes...", client);
           }
           else

--- a/src/ship_server/ship_server.c
+++ b/src/ship_server/ship_server.c
@@ -12190,6 +12190,35 @@ void Send06 (BANANA* client)
             SendB0 ("Invalid Section ID specified...", client);
         }
       }
+
+      if (!strcmp(myCommand, "modcharname"))
+      {
+        if ( myCmdArgs == 0 )
+          SendB0 ("Need to specify new name...", client);
+        else
+        {
+          if ( strlen ( myArgs[0] ) > 10)
+          {
+            SendB0 ("Name can only be up to 10 characters...", client);
+          }
+          else
+          {
+            size_t arglen = strlen(myArgs[0]);
+            size_t i = 0;
+            size_t index = 0;
+            for (; i < arglen; i++){
+              index = 4 + (i * 2);
+              sprintf( &client->character.name[index], "%c", myArgs[0][i] );
+              client->character.name[index+1] = 0;
+            }
+            index = 4 + (arglen *2);
+            memset (&client->character.name[index], '\0', 24 - (arglen*2));
+            SendB0 ("Character name changes to: ", client);
+            SendB0 (Unicode_to_ASCII ((uint16_t*) &client->character.name[4]), client);
+            SendB0 ("\nPlease change blocks to reflect changes...\n", client);
+          }
+        }
+      }
     }
   }
   else

--- a/src/ship_server/ship_server.c
+++ b/src/ship_server/ship_server.c
@@ -12103,6 +12103,17 @@ void Send06 (BANANA* client)
       {
         ReloadAllQuests();
       }
+      if ( !strcmp ( myCommand, "showmats" ) )
+      {
+        if ( client->lobbyNum < 0x10 )
+          SendB0 ("Can't show mats in the lobby!!!", client);
+        else
+        {
+          char usedmats[41];
+          sprintf(usedmats, "ATP:%d MST:%d EVP:%d DFP:%d LCK:%d\n", client->matuse[0], client->matuse[1], client->matuse[2], client->matuse[3], client->matuse[4]);
+          SendB0 (usedmats, client);
+        }
+      }
     }
   }
   else


### PR DESCRIPTION
corrects .BEAT time by implimenting the SENDB1 in login_server.c, which had previously been stubbed in order to compile in linux. Uses gmtime() to be timezon agnostic and correctly match global Swatch / .BEAT time.

Includes additional player /commands "/showmats" and "/resetmymats" because i am git newbie and didnt know how to do pull requests for single files.